### PR TITLE
매장 컨트롤러 수정, 매장 상세 페이지 수정, 매장 전체 조회 javascript 수정

### DIFF
--- a/src/main/java/com/happy/para/ctrl/StoreCtrl.java
+++ b/src/main/java/com/happy/para/ctrl/StoreCtrl.java
@@ -207,7 +207,8 @@ public class StoreCtrl {
 	}
 	
 	//delStore.do
-	@RequestMapping(value="/delStore.do", method=RequestMethod.GET)
+	@RequestMapping(value="/delStore.do", method=RequestMethod.POST)
+	@ResponseBody
 	public String deleteStore(String store_code) {
 		logger.info("delete Store Controller : {}", store_code);
 		boolean isc = storeService.storeDelete(store_code);
@@ -217,7 +218,7 @@ public class StoreCtrl {
 		System.out.println("매장삭제 시 삭제된 매장의 재고 삭제 : " + delStock);
 		
 		
-		return "redirect:/selStoreList.do";
+		return delStock+"";
 	}
 	
 	@RequestMapping(value="/storePaging.do", method=RequestMethod.POST, produces="application/text; charset=UTF-8")

--- a/src/main/webapp/WEB-INF/view/store/storeDetail.jsp
+++ b/src/main/webapp/WEB-INF/view/store/storeDetail.jsp
@@ -42,7 +42,7 @@
 				</div>
 				<div id="btnDiv" align="right">
 					<input type="button" class="btn btn-outline-success" id="modiForm" value="수정" onclick="modiStoreForm()">
-					<input type="button" class="btn btn-outline-success" id="deleteStore" value="삭제" onclick="delStore()">
+					<input type="button" class="btn btn-outline-success" id="deleteStore" value="삭제" onclick="delStore('${dto.store_code}')">
 					<input type="button" class="btn btn-outline-success" id="close" value="닫기" onclick="modiCancel()">
 				</div>
 			</fieldset>
@@ -68,7 +68,7 @@
 				data : $("#frm").serialize(),
 				dataType:"json",
 				success : function(msg){
-					alert("왜안되야");
+// 					alert("왜안되야");
 					swal({
 						title: "수정 완료", 
 						text: "매장 수정이 완료되었습니다", 
@@ -104,7 +104,7 @@
 										+"</div>"
 										+"<div id='btnDiv' align='right'>"
 											+"<input type='button' class='btn btn-outline-success' id='modiForm' value='수정' onclick='modiStoreForm()'>"
-											+"<input type='button' class='btn btn-outline-success' id='deleteStore' value='삭제' onclick='delStore()'>"
+											+"<input type='button' class='btn btn-outline-success' id='deleteStore' value='삭제' onclick='delStore(\""+msg.store_code+"\")'>"
 											+"<input type='button' class='btn btn-outline-success' id='close' value='닫기' onclick='modiCancel()'>"
 										+"</div>";
 						$("#detailStore").html(htmlDetail);
@@ -118,6 +118,48 @@
 		}
 		var modiCancel = function(){
 			self.close();
+		}
+		
+		var delStore = function(storeCode){
+			swal({
+				title: "삭제 확인",
+				text: "정말 삭제하시겠습니까?",
+				type: "warning",
+				showCancelButton: true,
+				confirmButtonColor: "lightgray",
+				confirmButtonText: "취 소",
+				cancelButtonText: "확 인",
+				closeOnConfirm: false,
+				closeOnCancel: false
+			},
+			function(isConfirm){
+				if(isConfirm){ // confirmButtonText
+					swal("취소", "매장 정보 삭제가 취소 되었습니다.", "error");
+//		 			return false;
+				} else{ // cancelButtonText
+					// 확인 했을 때
+					$.ajax({
+						type: "post",
+						url: "./delStore.do",
+						data: "store_code="+storeCode,
+						async : false,
+						success: function (data) {
+				        	swal({
+								title: "삭제 완료", 
+								text: "매장 정보 삭제가 완료되었습니다", 
+								type: "success"
+							},
+							function(){ 
+								opener.parent.location.reload();
+								modiCancel();
+							});
+						},
+				        error: function (data) {
+				        	swal("삭제 에러", "삭제 중 문제가 발생하였습니다.", "error");
+				        }
+					});
+				}
+			});
 		}
 	</script>
 </body>

--- a/src/main/webapp/js/storeList.js
+++ b/src/main/webapp/js/storeList.js
@@ -132,7 +132,7 @@ var pageAjax = function(){
 						
 						htmlTable +="<tr>" +
 								"<td>"+fri.store_code+"</td>" +
-								"<td><a href='./selStoreDetail.do?store_code="+fri.store_code+"'>"+fri.store_name+"</a></td>" +
+								"<td><a href='#' onclick=storeDetail('"+fri.store_code+"')>"+fri.store_name+"</a></td>" +
 								"<td>"+fri.store_address+"</td>+" +
 								"<td>"+fri.store_phone+"</td></tr>";
 					});


### PR DESCRIPTION
매장 삭제 method ajax 처리를 위한 @ResponseBody annotation 추가
매장 상세 페이지에서 매장 수정 시 화면에 뿌려지는 삭제 버튼에 store_code 값 파라미터 추가
매장 수정 성공 시 확인용으로 작성한 alert() 주석처리
매장 전체 조회 후 페이징 처리 시 뿌려지는 매장 상세 조회 a 태그에 onclick 이벤트 처리, 페이징 이동 후에도 새 창에서
매장 상세 조회 페이지가 뜨게 처리

PaRaPaRa 조원 김태현 : 2019-05-27